### PR TITLE
list missing lanes after qc complete

### DIFF
--- a/modules/UpdatePipeline/Validate.pm
+++ b/modules/UpdatePipeline/Validate.pm
@@ -96,7 +96,7 @@ sub _build_report
     else
     {
       # file missing from tracking database
-      if($file_metadata->total_reads > 10000)
+      if($file_metadata->total_reads > 10000 && $file_metadata->lane_manual_qc ne 'pending')
       {
         push(@{$inconsistent_files{files_missing_from_tracking}}, $file_metadata->file_name_without_extension);
       }


### PR DESCRIPTION
Pipeline health report lists lane as missing after qc completed.
